### PR TITLE
Fix reissue and renew commands returning error status code on success

### DIFF
--- a/bin/sslmate
+++ b/bin/sslmate
@@ -1847,7 +1847,8 @@ sub command_reissue {
 	}
 
 	print "Reissue complete.\n\n";
-	return do_wait_for_cert($cn, $cert_instance, $no_wait, 0, $paths, $new_key_filename);
+	do_wait_for_cert($cn, $cert_instance, $no_wait, 0, $paths, $new_key_filename);
+	return 0;
 }
 
 sub command_revoke {
@@ -2104,7 +2105,8 @@ sub command_renew {
 	}
 
 	print "Renewal complete.\n\n";
-	return do_wait_for_cert($cn, $cert_instance, $no_wait, 0, $paths);
+	do_wait_for_cert($cn, $cert_instance, $no_wait, 0, $paths);
+	return 0;
 }
 
 sub command_req {


### PR DESCRIPTION
When reissue or renew were called, the command line tool was exiting with a status code of 1, even if the command successfully completed.  Since this is considered a failure, this made it a little tricky to write wrapper scripts around these commands. This fix ensures these commands exit with a successful exit code of 0 if they were actually successful.

(This could also be fixed by having `do_wait_for_cert` itself return 0, but it seemed like having the `command_*` methods explicitly return 0 was more consistent with how the other `command_*` methods are currently implemented.)