### PR TITLE
Allow 3 and 4 in passwords and Ctrl+C to work

### DIFF
--- a/bin/sslmate
+++ b/bin/sslmate
@@ -196,7 +196,7 @@ sub prompt_password {
 	print $message;
 
 	my $password = '';
-	ReadMode(3);
+	ReadMode(4);
 	my %ctrl = GetControlChars;
 	while (defined(my $key = ReadKey(0))) {
 		if ($key eq "\n" || $key eq "\r" || ord($key) eq $ctrl{EOF}) { # e.g. Ctrl+D

--- a/bin/sslmate
+++ b/bin/sslmate
@@ -196,25 +196,12 @@ sub prompt_password {
 	print $message;
 
 	my $password = '';
-	ReadMode(4);
+	ReadMode(3);
 	my %ctrl = GetControlChars;
 	while (defined(my $key = ReadKey(0))) {
-		if ($key eq "\n" || $key eq "\r" || $key eq $ctrl{EOF}) { # e.g. Ctrl+D
+		if ($key eq "\n" || $key eq "\r") {
 			print "\n";
 			last;
-		} elsif ($key eq $ctrl{INTERRUPT}) { # e.g. Ctrl+C
-			$password = undef;
-			last;
-		} elsif ($key eq $ctrl{ERASE}) {
-			if ($password ne '') {
-				chop $password;
-				print "\b \b";
-			}
-		} elsif ($key eq $ctrl{KILL} || $key eq $ctrl{ERASEWORD}) { # e.g. Ctrl+U, Ctrl+W
-			while ($password ne '') {
-				chop $password;
-				print "\b \b";
-			}
 		} else {
 			$password = $password . $key;
 			print "*";


### PR DESCRIPTION
If my password has a 3 or 4 in it I'm unable to continue as the INTERRUPT or EOF control characters match. Ctrl+C, Ctrl+D or the others never seem to work any ways so remove those checks as well.

With the attached diff, Ctrl+C will work to break out, but also allow any numbers as they won't be matched to control characters. If you mess up your password just Ctrl+C and reissue sslmate link.